### PR TITLE
chore: remove distributionManagement section

### DIFF
--- a/google-cloud-websecurityscanner-bom/pom.xml
+++ b/google-cloud-websecurityscanner-bom/pom.xml
@@ -39,17 +39,6 @@
     <url>https://github.com/googleapis/java-websecurityscanner</url>
   </scm>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>sonatype-nexus-snapshots</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>sonatype-nexus-staging</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
All java client libraries inherit the distributionManagement section form shared-config. To prevent individual pom files from overriding the shared-config version of distributionManagement, it is being removed.